### PR TITLE
fix: skip "vanilla-extract" plugin for child compiler

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "remix-vite-vanilla-repro",
   "private": true,
-  "sideEffects": false,
   "type": "module",
   "scripts": {
     "remix:build": "remix build",
@@ -34,5 +33,10 @@
   },
   "engines": {
     "node": ">=14.0.0"
+  },
+  "pnpm": {
+    "patchedDependencies": {
+      "@remix-run/dev@2.2.0": "patches/@remix-run__dev@2.2.0.patch"
+    }
   }
 }

--- a/patches/@remix-run__dev@2.2.0.patch
+++ b/patches/@remix-run__dev@2.2.0.patch
@@ -1,0 +1,13 @@
+diff --git a/dist/vite/plugin.js b/dist/vite/plugin.js
+index 3f025ab178692932a2c3b6527d5d82a60021f8b6..0ea80a5849ebe91dcacf6ea4a3bc8f9fd9b82568 100644
+--- a/dist/vite/plugin.js
++++ b/dist/vite/plugin.js
+@@ -357,7 +357,7 @@ const remixVitePlugin = (options = {}) => {
+         // disk from the child compiler. This is important in the
+         // production build because the child compiler is a Vite dev
+         // server and will generate incorrect manifests.
+-        .filter(plugin => typeof plugin === "object" && plugin !== null && "name" in plugin && plugin.name !== "remix" && plugin.name !== "remix-hmr-updates"), {
++        .filter(plugin => typeof plugin === "object" && plugin !== null && "name" in plugin && plugin.name !== "vanilla-extract" && plugin.name !== "remix" && plugin.name !== "remix-hmr-updates"), {
+           name: "no-hmr",
+           handleHotUpdate() {
+             // parent vite server is already sending HMR updates

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,14 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+patchedDependencies:
+  '@remix-run/dev@2.2.0':
+    hash: qytcly2yz7emrso6zgn4j6f6cu
+    path: patches/@remix-run__dev@2.2.0.patch
+
 dependencies:
   '@remix-run/css-bundle':
     specifier: ^2.2.0
@@ -26,7 +35,7 @@ dependencies:
 devDependencies:
   '@remix-run/dev':
     specifier: ^2.2.0
-    version: 2.2.0(@remix-run/serve@2.2.0)(typescript@5.2.2)(vite@4.5.0)
+    version: 2.2.0(patch_hash=qytcly2yz7emrso6zgn4j6f6cu)(@remix-run/serve@2.2.0)(typescript@5.2.2)(vite@4.5.0)
   '@remix-run/eslint-config':
     specifier: ^2.2.0
     version: 2.2.0(eslint@8.27.0)(react@18.2.0)(typescript@5.2.2)
@@ -1085,7 +1094,7 @@ packages:
     engines: {node: '>=18.0.0'}
     dev: false
 
-  /@remix-run/dev@2.2.0(@remix-run/serve@2.2.0)(typescript@5.2.2)(vite@4.5.0):
+  /@remix-run/dev@2.2.0(patch_hash=qytcly2yz7emrso6zgn4j6f6cu)(@remix-run/serve@2.2.0)(typescript@5.2.2)(vite@4.5.0):
     resolution: {integrity: sha512-JtteMtYirQlj1Xf9FSLLjqO+owxlqJVsTESgVWdF+CR5kon2i12YjPnRx1xGtB4UGgU/yTZseMTPNhTKc5mwpQ==}
     engines: {node: '>=18.0.0'}
     hasBin: true
@@ -1175,6 +1184,7 @@ packages:
       - ts-node
       - utf-8-validate
     dev: true
+    patched: true
 
   /@remix-run/eslint-config@2.2.0(eslint@8.27.0)(react@18.2.0)(typescript@5.2.2):
     resolution: {integrity: sha512-H+LPiQhsXaCsOVvyB5vf6wTAv72m/pI6rdoCjyx3ayipNGAuqldkAnmFD6Qa/Bpc/zRHk13+PZV27kjyNd32vw==}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,4 +14,7 @@ export default defineConfig({
       emitCssInSsr: true, // ! flash of *styled* content without it
     }),
   ],
+  build: {
+    minify: false,
+  }
 });


### PR DESCRIPTION
Sorry to spam with the PRs. I thought you might be interested in, so I created it here.
If you don't want to be bothered by this, then please let me know. I'll move this change to my own repo without notifying you.

Here, I found another less-general but potential workaround for vanilla extract.
(See https://github.com/remix-run/remix/pull/7994 for the detail).
